### PR TITLE
fix: profile edit validation error

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -18,15 +18,16 @@ class ProfileController extends Controller
         return view('profile', ['user' => $user, 'lastPost' => $lastPost, 'postsCount' => $postsCount]);
     }
     public function edit(Request $request) {
-        $request->validate([
-            'email' => 'required|email|unique:users',
-            'school_year' => 'required',
-            'biography' => 'required'
-        ]);
-
         $user = Auth::user();
-        $user->email = $request->email;
-        $user->school_year = $request->school_year;
+
+        if ($request->email != $user->email) {
+            $request->validate([
+                'email' => 'unique:users',
+            ]); 
+            $user->email = $request->email;
+        }
+
+        $user->school_year = $request->school_year ?? $user->school_year;
         $user->biography = $request->biography;
         $user->save();
         return back();


### PR DESCRIPTION
The profile page wasn't editing, the reason for this was that the validation is asking for an unique email, but that only should happen when the user wants to change their email.

Before this, it checked if the email was unique, and it never was when it wasn't changed, because the profile editing user was using that email. That's why the profile editing only worked sometimes.